### PR TITLE
Fix attachment filtering in set attributes service

### DIFF
--- a/spec/services/work_packages/activities_tab/comment_attachments_claims/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/activities_tab/comment_attachments_claims/set_attributes_service_spec.rb
@@ -84,6 +84,10 @@ RSpec.describe WorkPackages::ActivitiesTab::CommentAttachmentsClaims::SetAttribu
         allow(Attachment).to receive(:where)
           .with(id: [assigned_attachment.id.to_s, unattached_attachment.id.to_s])
           .and_return([assigned_attachment, unattached_attachment])
+        # A second call happens when setting the filtered replacements
+        allow(Attachment).to receive(:where)
+          .with(id: [unattached_attachment.id.to_s])
+          .and_return([unattached_attachment])
       end
 
       it "filters out the assigned attachment and only sets unattached ones" do


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
This PR addresses a failing test in https://github.com/opf/openproject/pull/19925.

# What are you trying to accomplish?
Fix a failing RSpec test for `WorkPackages::ActivitiesTab::CommentAttachmentsClaims::SetAttributesService#call` that occurred due to an unstubbed second database query.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->
N/A

# What approach did you choose and why?
The failing test `WorkPackages::ActivitiesTab::CommentAttachmentsClaims::SetAttributesService#call when the journal notes reference an attachment already assigned to a container filters out the assigned attachment and only sets unattached ones` was failing because the `Attachment.where` method was being called twice within the service.

The service first loads all referenced attachment IDs, then filters out those already assigned to a container. This results in a second `Attachment.where` call with a reduced set of IDs (only the unattached ones). The original spec only stubbed the first `Attachment.where` call.

The chosen approach was to add a second `allow(Attachment).to receive(:where)` stub for the filtered set of attachment IDs. This ensures that both `Attachment.where` calls are correctly stubbed, aligning the test's expectations with the service's actual behavior.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)

---
<a href="https://cursor.com/background-agent?bcId=bc-3134d8a8-1190-4072-b507-e5d9a10ce570">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3134d8a8-1190-4072-b507-e5d9a10ce570">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

